### PR TITLE
correct example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ There is an example packer build with goss tests in the `example/` directory.
       "goss/goss.yaml"
     ],
     "downloadPath": "/tmp/goss-VERSION-linux-ARCH",
-    "remoteFolder": "/tmp",
-    "remotePath": "/tmp/goss",
+    "remote_folder": "/tmp",
+    "remote_path": "/tmp/goss",
     "skipInstall": false,
     "debug": false
   }


### PR DESCRIPTION
While attempting to change the default remote folder and path location, I encountered this error:
```
1 error(s) occurred:

* unknown configuration key: "remoteFolder"
```

Had to change to `remote_folder` and `remote_path`.