### PR TITLE
Adding step 4 for setting plugin executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ There is an example packer build with goss tests in the `example/` directory.
 >
 > The current working directory.
 
+4. Set binary to be executable `chmod +x packer-provisioner-goss`
+
 ## Author
 
 E. Camden Fisher <camden.fisher@yale.edu>


### PR DESCRIPTION
Ran into #13 myself when setting up the plugin, figured I'd add the mention of making the plugin executable.

Should fulfill #13 