### PR TITLE
Add support for supplying --var file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ There is an example packer build with goss tests in the `example/` directory.
     "use_sudo": false,
     "format": "",
     "goss_file": "",
+    "vars_file": "",
     "username": "",
     "password": "",
     "debug": false

--- a/packer-provisioner-goss.go
+++ b/packer-provisioner-goss.go
@@ -38,6 +38,12 @@ type GossConfig struct {
 	// The --gossfile flag
 	GossFile string `mapstructure:"goss_file"`
 
+	// The --vars flag
+	// Optional file containing variables, used within GOSS templating.
+	// Must be one of the files contained in the Tests array.
+	// Can be YAML or JSON.
+	VarsFile string `mapstructure:"vars_file"`
+
 	// The remote folder where the goss tests will be uploaded to.
 	// This should be set to a pre-existing directory, it defaults to /tmp
 	RemoteFolder string `mapstructure:"remote_folder"`
@@ -115,6 +121,10 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	if p.config.GossFile != "" {
 		p.config.GossFile = fmt.Sprintf("--gossfile %s", p.config.GossFile)
+	}
+
+	if p.config.VarsFile != "" {
+		p.config.VarsFile = fmt.Sprintf("--vars %s", p.config.VarsFile)
 	}
 
 	var errs *packer.MultiError
@@ -235,8 +245,8 @@ func (p *Provisioner) runGoss(ui packer.Ui, comm packer.Communicator) error {
 	goss := fmt.Sprintf("%s", p.config.DownloadPath)
 	cmd := &packer.RemoteCmd{
 		Command: fmt.Sprintf(
-			"cd %s && %s %s %s %s validate %s",
-			p.config.RemotePath, p.enableSudo(), goss, p.config.GossFile, p.debug(), p.format()),
+			"cd %s && %s %s %s %s %s validate %s",
+			p.config.RemotePath, p.enableSudo(), goss, p.config.GossFile, p.config.VarsFile, p.debug(), p.format()),
 	}
 	if err := cmd.StartWithUi(comm, ui); err != nil {
 		return err

--- a/packer-provisioner-goss.go
+++ b/packer-provisioner-goss.go
@@ -123,10 +123,6 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		p.config.GossFile = fmt.Sprintf("--gossfile %s", p.config.GossFile)
 	}
 
-	if p.config.VarsFile != "" {
-		p.config.VarsFile = fmt.Sprintf("--vars %s", p.config.VarsFile)
-	}
-
 	var errs *packer.MultiError
 	if p.config.Format != "" {
 		valid := false
@@ -246,7 +242,7 @@ func (p *Provisioner) runGoss(ui packer.Ui, comm packer.Communicator) error {
 	cmd := &packer.RemoteCmd{
 		Command: fmt.Sprintf(
 			"cd %s && %s %s %s %s %s validate %s",
-			p.config.RemotePath, p.enableSudo(), goss, p.config.GossFile, p.config.VarsFile, p.debug(), p.format()),
+			p.config.RemotePath, p.enableSudo(), goss, p.config.GossFile, p.vars(), p.debug(), p.format()),
 	}
 	if err := cmd.StartWithUi(comm, ui); err != nil {
 		return err
@@ -269,6 +265,13 @@ func (p *Provisioner) debug() string {
 func (p *Provisioner) format() string {
 	if p.config.Format != "" {
 		return fmt.Sprintf("-f %s", p.config.Format)
+	}
+	return ""
+}
+
+func (p *Provisioner) vars() string {
+	if p.config.VarsFile != "" {
+		return fmt.Sprintf("--vars %s", p.config.VarsFile)
 	}
 	return ""
 }


### PR DESCRIPTION
So that one can take advantage of goss' templating feature, add support to upload, then use, a vars file.

goss docs: https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#templates