### PR TITLE
Adding a Dockerfile for packer with the goss provisioner installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.13
+
+ENV GOOS=linux
+ENV GOARCH=amd64
+ENV CGO_ENABLED=0
+
+ADD . /app
+WORKDIR /app
+RUN go get \
+ && go build -o packer-provisioner-goss
+
+FROM hashicorp/packer:light
+COPY --from=0 /app/packer-provisioner-goss /bin/packer-provisioner-goss


### PR DESCRIPTION
Simple Dockerfile to build an image based on the official `hashicorp/packer:light`, with the goss provisioner installed. The provisioner must be built with CGO_ENABLED=0 for it to work on alpine.