### PR TITLE
Install aws cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,7 @@ RUN go get \
 
 FROM hashicorp/packer:light
 COPY --from=0 /app/packer-provisioner-goss /bin/packer-provisioner-goss
+
+RUN apk add python \
+&& apk add py-pip \
+&& python -m pip install awscli


### PR DESCRIPTION
In order to install aws command line interface I needed to install python and pip. I could then install aws cli.