### PR TITLE
Fix & Enhance Goss packer provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ There is an example packer build with goss tests in the `example/` directory.
     "vars_file": "",
     "username": "",
     "password": "",
-    "debug": false,
     "retry_timeout": "0s",
     "sleep": "1s"
   }

--- a/packer-provisioner-goss.hcl2spec.go
+++ b/packer-provisioner-goss.hcl2spec.go
@@ -16,7 +16,6 @@ type FlatGossConfig struct {
 	Username      *string  `cty:"username"`
 	Password      *string  `cty:"password"`
 	SkipInstall   *bool    `cty:"skip_install"`
-	Debug         *bool    `cty:"debug"`
 	Tests         []string `cty:"tests"`
 	RetryTimeout  *string  `mapstructure:"retry_timeout" cty:"retry_timeout"`
 	Sleep         *string  `mapstructure:"sleep" cty:"sleep"`
@@ -49,7 +48,6 @@ func (*FlatGossConfig) HCL2Spec() map[string]hcldec.Spec {
 		"username":       &hcldec.AttrSpec{Name: "username", Type: cty.String, Required: false},
 		"password":       &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
 		"skip_install":   &hcldec.AttrSpec{Name: "skip_install", Type: cty.Bool, Required: false},
-		"debug":          &hcldec.AttrSpec{Name: "debug", Type: cty.Bool, Required: false},
 		"tests":          &hcldec.AttrSpec{Name: "tests", Type: cty.List(cty.String), Required: false},
 		"retry_timeout":  &hcldec.AttrSpec{Name: "retry_timeout", Type: cty.String, Required: false},
 		"sleep":          &hcldec.AttrSpec{Name: "sleep", Type: cty.String, Required: false},

--- a/packer-provisioner-goss.hcl2spec.go
+++ b/packer-provisioner-goss.hcl2spec.go
@@ -9,24 +9,25 @@ import (
 // FlatGossConfig is an auto-generated flat version of GossConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatGossConfig struct {
-	Version      *string  `cty:"version"`
-	Arch         *string  `cty:"arch"`
-	URL          *string  `cty:"url"`
-	DownloadPath *string  `cty:"download_path"`
-	Username     *string  `cty:"username"`
-	Password     *string  `cty:"password"`
-	SkipInstall  *bool    `cty:"skip_install"`
-	Debug        *bool    `cty:"debug"`
-	Tests        []string `cty:"tests"`
-	RetryTimeout *string  `mapstructure:"retry_timeout" cty:"retry_timeout"`
-	Sleep        *string  `mapstructure:"sleep" cty:"sleep"`
-	UseSudo      *bool    `mapstructure:"use_sudo" cty:"use_sudo"`
-	SkipSSLChk   *bool    `mapstructure:"skip_ssl" cty:"skip_ssl"`
-	GossFile     *string  `mapstructure:"goss_file" cty:"goss_file"`
-	VarsFile     *string  `mapstructure:"vars_file" cty:"vars_file"`
-	RemoteFolder *string  `mapstructure:"remote_folder" cty:"remote_folder"`
-	RemotePath   *string  `mapstructure:"remote_path" cty:"remote_path"`
-	Format       *string  `mapstructure:"format" cty:"format"`
+	Version       *string  `cty:"version"`
+	Arch          *string  `cty:"arch"`
+	URL           *string  `cty:"url"`
+	DownloadPath  *string  `cty:"download_path"`
+	Username      *string  `cty:"username"`
+	Password      *string  `cty:"password"`
+	SkipInstall   *bool    `cty:"skip_install"`
+	Debug         *bool    `cty:"debug"`
+	Tests         []string `cty:"tests"`
+	RetryTimeout  *string  `mapstructure:"retry_timeout" cty:"retry_timeout"`
+	Sleep         *string  `mapstructure:"sleep" cty:"sleep"`
+	UseSudo       *bool    `mapstructure:"use_sudo" cty:"use_sudo"`
+	SkipSSLChk    *bool    `mapstructure:"skip_ssl" cty:"skip_ssl"`
+	GossFile      *string  `mapstructure:"goss_file" cty:"goss_file"`
+	VarsFile      *string  `mapstructure:"vars_file" cty:"vars_file"`
+	RemoteFolder  *string  `mapstructure:"remote_folder" cty:"remote_folder"`
+	RemotePath    *string  `mapstructure:"remote_path" cty:"remote_path"`
+	Format        *string  `mapstructure:"format" cty:"format"`
+	FormatOptions *string  `mapstructure:"format_options" cty:"format_options"`
 }
 
 // FlatMapstructure returns a new FlatGossConfig.
@@ -41,24 +42,25 @@ func (*GossConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Sp
 // The decoded values from this spec will then be applied to a FlatGossConfig.
 func (*FlatGossConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"version":       &hcldec.AttrSpec{Name: "version", Type: cty.String, Required: false},
-		"arch":          &hcldec.AttrSpec{Name: "arch", Type: cty.String, Required: false},
-		"url":           &hcldec.AttrSpec{Name: "url", Type: cty.String, Required: false},
-		"download_path": &hcldec.AttrSpec{Name: "download_path", Type: cty.String, Required: false},
-		"username":      &hcldec.AttrSpec{Name: "username", Type: cty.String, Required: false},
-		"password":      &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
-		"skip_install":  &hcldec.AttrSpec{Name: "skip_install", Type: cty.Bool, Required: false},
-		"debug":         &hcldec.AttrSpec{Name: "debug", Type: cty.Bool, Required: false},
-		"tests":         &hcldec.AttrSpec{Name: "tests", Type: cty.List(cty.String), Required: false},
-		"retry_timeout": &hcldec.AttrSpec{Name: "retry_timeout", Type: cty.String, Required: false},
-		"sleep":         &hcldec.AttrSpec{Name: "sleep", Type: cty.String, Required: false},
-		"use_sudo":      &hcldec.AttrSpec{Name: "use_sudo", Type: cty.Bool, Required: false},
-		"skip_ssl":      &hcldec.AttrSpec{Name: "skip_ssl", Type: cty.Bool, Required: false},
-		"goss_file":     &hcldec.AttrSpec{Name: "goss_file", Type: cty.String, Required: false},
-		"vars_file":     &hcldec.AttrSpec{Name: "vars_file", Type: cty.String, Required: false},
-		"remote_folder": &hcldec.AttrSpec{Name: "remote_folder", Type: cty.String, Required: false},
-		"remote_path":   &hcldec.AttrSpec{Name: "remote_path", Type: cty.String, Required: false},
-		"format":        &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
+		"version":        &hcldec.AttrSpec{Name: "version", Type: cty.String, Required: false},
+		"arch":           &hcldec.AttrSpec{Name: "arch", Type: cty.String, Required: false},
+		"url":            &hcldec.AttrSpec{Name: "url", Type: cty.String, Required: false},
+		"download_path":  &hcldec.AttrSpec{Name: "download_path", Type: cty.String, Required: false},
+		"username":       &hcldec.AttrSpec{Name: "username", Type: cty.String, Required: false},
+		"password":       &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
+		"skip_install":   &hcldec.AttrSpec{Name: "skip_install", Type: cty.Bool, Required: false},
+		"debug":          &hcldec.AttrSpec{Name: "debug", Type: cty.Bool, Required: false},
+		"tests":          &hcldec.AttrSpec{Name: "tests", Type: cty.List(cty.String), Required: false},
+		"retry_timeout":  &hcldec.AttrSpec{Name: "retry_timeout", Type: cty.String, Required: false},
+		"sleep":          &hcldec.AttrSpec{Name: "sleep", Type: cty.String, Required: false},
+		"use_sudo":       &hcldec.AttrSpec{Name: "use_sudo", Type: cty.Bool, Required: false},
+		"skip_ssl":       &hcldec.AttrSpec{Name: "skip_ssl", Type: cty.Bool, Required: false},
+		"goss_file":      &hcldec.AttrSpec{Name: "goss_file", Type: cty.String, Required: false},
+		"vars_file":      &hcldec.AttrSpec{Name: "vars_file", Type: cty.String, Required: false},
+		"remote_folder":  &hcldec.AttrSpec{Name: "remote_folder", Type: cty.String, Required: false},
+		"remote_path":    &hcldec.AttrSpec{Name: "remote_path", Type: cty.String, Required: false},
+		"format":         &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
+		"format_options": &hcldec.AttrSpec{Name: "format_options", Type: cty.String, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
- Debug option is omitted as it is not supported for `goss validate`
- Download path is correctly deduced if URl is provided
- Add `format options` config option for the output.