### PR TITLE
Add support for passing environment variables to GOSS execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ There is an example packer build with goss tests in the `example/` directory.
     "format": "",
     "goss_file": "",
     "vars_file": "",
+    "vars_env": {
+      "ARCH": "amd64",
+      "PROVIDER": "{{user `cloud-provider`}}"
+    },
     "vars_inline": {
       "OS": "centos",
       "version": "{{user `version`}}"

--- a/packer-provisioner-goss.hcl2spec.go
+++ b/packer-provisioner-goss.hcl2spec.go
@@ -24,6 +24,7 @@ type FlatGossConfig struct {
 	GossFile      *string           `mapstructure:"goss_file" cty:"goss_file"`
 	VarsFile      *string           `mapstructure:"vars_file" cty:"vars_file"`
 	VarsInline    map[string]string `mapstructure:"vars_inline" cty:"vars_inline"`
+	VarsEnv       map[string]string `mapstructure:"vars_env" cty:"vars_env"`
 	RemoteFolder  *string           `mapstructure:"remote_folder" cty:"remote_folder"`
 	RemotePath    *string           `mapstructure:"remote_path" cty:"remote_path"`
 	Format        *string           `mapstructure:"format" cty:"format"`
@@ -58,6 +59,7 @@ func (*FlatGossConfig) HCL2Spec() map[string]hcldec.Spec {
 		"goss_file":      &hcldec.AttrSpec{Name: "goss_file", Type: cty.String, Required: false},
 		"vars_file":      &hcldec.AttrSpec{Name: "vars_file", Type: cty.String, Required: false},
 		"vars_inline":    &hcldec.AttrSpec{Name: "vars_inline", Type: cty.Map(cty.String), Required: false},
+		"vars_env":       &hcldec.AttrSpec{Name: "vars_env", Type: cty.Map(cty.String), Required: false},
 		"remote_folder":  &hcldec.AttrSpec{Name: "remote_folder", Type: cty.String, Required: false},
 		"remote_path":    &hcldec.AttrSpec{Name: "remote_path", Type: cty.String, Required: false},
 		"format":         &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},


### PR DESCRIPTION
Helps support GOSS feature for templating with env variables 
https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#templates
```
Available variables:

{{.Env}} - Containing environment variables
```
Also, I believe it is important to be able to modify the execution shell for any future debug/log options too.


Results from a run

```
 amazon-2: Env variables are OS="amazon linux" ARCH="amd64" PROVIDER="amazon"
    amazon-2: Uploading Dir packer/goss
    amazon-2: Creating directory: /tmp/goss/goss
==> amazon-2:
==> amazon-2:
==> amazon-2:
==> amazon-2: Running goss tests...
    amazon-2: Command : cd /tmp/goss && sudo ARCH="amd64" PROVIDER="amazon" OS="amazon linux"  /tmp/goss-0.3.13-linux-amd64 --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"containerd_version":"1.3.4","kubernetes_cni_source_type":"pkg","kubernetes_cni_version":"0.8.6","kubernetes_source_type":"pkg","kubernetes_version":"1.16.11"}' validate --retry-timeout 0s --sleep 1s -f json -o pretty
    amazon-2: {
```