### PR TITLE
Add support to download goss spec form remote VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ There is an example packer build with goss tests in the `example/` directory.
 ]
 ```
 
+## Spec files
+Goss spec file and debug spec file (`goss render -d`) are downloaded to `/tmp` folder on local machine from the remote VM. These files are exact specs GOSS validated on the VM. The downloaded GOSS spec can be used to validate any other VM image for equivalency.  
+
 ## Installation
 
 1. Download the most recent release for your platform from [here.](https://github.com/YaleUniversity/packer-provisioner-goss/releases).


### PR DESCRIPTION
This adds support for downloading `goss-spec` and `debug goss-spec` to `/tmp` folder on local machine.

This spec then can be added to images' release manifest or notes as a verification receipt.

```
==> amazon-2: Downloading spec file and debug info
    amazon-2: Downloading Goss specs from, /tmp/goss-spec.yaml and /tmp/debug-goss-spec.yaml to current dir
```

```
~/workspace/eleanor/packer-provisioner-goss(ta-AddVisibility) » ls -al /tmp/*goss*            taggarwal@taggarwal-a01
-rw-r--r--  1 taggarwal  wheel  4724 Aug 28 15:44 /tmp/debug-goss-spec.yaml
-rw-r--r--  1 taggarwal  wheel  2179 Aug 28 15:44 /tmp/goss-spec.yaml
```
