### PR TITLE
Fix problem when using hcl2 for packer templates.

### DIFF
--- a/packer-provisioner-goss.go
+++ b/packer-provisioner-goss.go
@@ -28,10 +28,10 @@ type GossConfig struct {
 	Version      string
 	Arch         string
 	URL          string
-	DownloadPath string
+	DownloadPath string `mapstructure:"download_path"`
 	Username     string
 	Password     string
-	SkipInstall  bool
+	SkipInstall  bool `mapstructure:"skip_install"`
 	Inspect      bool
 
 	// An array of tests to run.


### PR DESCRIPTION
The error message was `unknown configuration key "download_path"` and
`unknown configuration key "skip_install"`.