### PR TITLE
Add support for using goss to target Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Wouldn't it be nice if you could run [goss](https://github.com/aelsabbahy/goss) tests against an image during a packer build?
 
-Well, I thought it would, so now you can!  This currently only works for building a `linux` image since goss only runs in linux.
+Well, I thought it would, so now you can!  
 
 This runs during the provisioning process since the machine being provisioned is only available at that time.
 
@@ -50,6 +50,7 @@ There is an example packer build with goss tests in the `example/` directory.
     "format": "",
     "goss_file": "",
     "vars_file": "",
+    "targetOs": "Linux",
     "vars_env": {
       "ARCH": "amd64",
       "PROVIDER": "{{user `cloud-provider`}}"
@@ -66,6 +67,10 @@ There is an example packer build with goss tests in the `example/` directory.
 
 ## Spec files
 Goss spec file and debug spec file (`goss render -d`) are downloaded to `/tmp` folder on local machine from the remote VM. These files are exact specs GOSS validated on the VM. The downloaded GOSS spec can be used to validate any other VM image for equivalency.  
+
+## Windows support
+
+This now has support for Windows. Set the optional parameter `targetOs` to `Windows`. Currently, the `vars_env` parameter must include `GOSS_USE_ALPHA=1` as specified in [goss's feature parity document](https://github.com/aelsabbahy/goss/blob/master/docs/platform-feature-parity.md#platform-feature-parity).  In the future when goss come of of alpha for Windows this parameter will not be required.
 
 ## Installation
 
@@ -91,6 +96,7 @@ Goss spec file and debug spec file (`goss render -d`) are downloaded to `/tmp` f
 
 ```bash
 docker run --rm -it -v "$PWD":/usr/src/packer-provisioner-goss -w /usr/src/packer-provisioner-goss -e 'VERSION=v1.0.0' golang:1.13 bash
+go test ./...
 for GOOS in darwin linux windows; do
   for GOARCH in 386 amd64; do
     export GOOS GOARCH

--- a/packer-provisioner-goss.hcl2spec.go
+++ b/packer-provisioner-goss.hcl2spec.go
@@ -30,6 +30,7 @@ type FlatGossConfig struct {
 	Format        *string           `mapstructure:"format" cty:"format"`
 	FormatOptions *string           `mapstructure:"format_options" cty:"format_options"`
 	Inspect       *bool             `cty:"inspect"`
+	TargetOs      *string           `cty:"target_os"`
 }
 
 // FlatMapstructure returns a new FlatGossConfig.
@@ -65,6 +66,7 @@ func (*FlatGossConfig) HCL2Spec() map[string]hcldec.Spec {
 		"format":         &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
 		"format_options": &hcldec.AttrSpec{Name: "format_options", Type: cty.String, Required: false},
 		"inspect":        &hcldec.AttrSpec{Name: "inspect", Type: cty.Bool, Required: false},
+		"target_os":      &hcldec.AttrSpec{Name: "target_os", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/packer-provisioner-goss_test.go
+++ b/packer-provisioner-goss_test.go
@@ -51,7 +51,7 @@ func TestProvisioner_Prepare(t *testing.T) {
 				Password:      "",
 				SkipInstall:   false,
 				Inspect:       false,
-				TargetOs:      Linux,
+				TargetOs:      "Linux",
 				Tests:         []string{"example/goss"},
 				RetryTimeout:  "",
 				Sleep:         "",
@@ -89,7 +89,7 @@ func TestProvisioner_Prepare(t *testing.T) {
 				Password:     "",
 				SkipInstall:  false,
 				Inspect:      false,
-				TargetOs:     Windows,
+				TargetOs:     "Windows",
 				Tests:        []string{"example/goss"},
 				RetryTimeout: "",
 				Sleep:        "",
@@ -126,7 +126,7 @@ func TestProvisioner_Prepare(t *testing.T) {
 				Password:      "",
 				SkipInstall:   false,
 				Inspect:       false,
-				TargetOs:      Windows,
+				TargetOs:      "Windows",
 				Tests:         []string{"example/goss"},
 				RetryTimeout:  "",
 				Sleep:         "",
@@ -176,7 +176,7 @@ func TestProvisioner_envVars(t *testing.T) {
 		{
 			name: "Linux",
 			config: GossConfig{
-				TargetOs:      Linux,
+				TargetOs: "Linux",
 				VarsEnv: map[string]string{
 					"somevar": "1",
 				},
@@ -186,7 +186,7 @@ func TestProvisioner_envVars(t *testing.T) {
 		{
 			name: "Windows",
 			config: GossConfig{
-				TargetOs:      Windows,
+				TargetOs: "Windows",
 				VarsEnv: map[string]string{
 					"GOSS_USE_ALPHA": "1",
 				},
@@ -196,16 +196,16 @@ func TestProvisioner_envVars(t *testing.T) {
 		{
 			name: "no vars windows",
 			config: GossConfig{
-				TargetOs:      Windows,
-				VarsEnv: map[string]string{},
+				TargetOs: "Windows",
+				VarsEnv:  map[string]string{},
 			},
 			want: "",
 		},
 		{
 			name: "no vars linux",
 			config: GossConfig{
-				TargetOs:      Linux,
-				VarsEnv: map[string]string{},
+				TargetOs: "Linux",
+				VarsEnv:  map[string]string{},
 			},
 			want: "",
 		},
@@ -233,31 +233,31 @@ func TestProvisioner_envVars(t *testing.T) {
 
 func TestProvisioner_mkDir(t *testing.T) {
 	tests := []struct {
-		name   string
-		config GossConfig
-		dir   string
-		wantcmd   string
+		name    string
+		config  GossConfig
+		dir     string
+		wantcmd string
 	}{
 		{
 			name: "linux",
 			config: GossConfig{
-				TargetOs: Linux,
+				TargetOs: linux,
 			},
-			dir: "/tmp",
+			dir:     "/tmp",
 			wantcmd: "mkdir -p '/tmp'",
 		},
 		{
 			name: "windows",
 			config: GossConfig{
-				TargetOs: Windows,
+				TargetOs: windows,
 			},
-			dir: "/tmp",
+			dir:     "/tmp",
 			wantcmd: "powershell /c mkdir -p '/tmp'",
 		},
 		{
-			name: "no configured os",
-			config: GossConfig{},
-			dir: "/tmp",
+			name:    "no configured os",
+			config:  GossConfig{},
+			dir:     "/tmp",
 			wantcmd: "mkdir -p '/tmp'",
 		},
 	}

--- a/packer-provisioner-goss_test.go
+++ b/packer-provisioner-goss_test.go
@@ -1,0 +1,274 @@
+//go:generate mapstructure-to-hcl2 -type GossConfig
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/packer/template/interpolate"
+)
+
+func fakeContext() interpolate.Context {
+	var data map[interface{}]interface{}
+	var funcs map[string]interface{}
+	var userVars map[string]string
+	var sensitiveVars []string
+	return interpolate.Context{
+		Data:               data,
+		Funcs:              funcs,
+		UserVariables:      userVars,
+		SensitiveVariables: sensitiveVars,
+		EnableEnv:          false,
+		BuildName:          "",
+		BuildType:          "",
+		TemplatePath:       "",
+	}
+}
+
+func TestProvisioner_Prepare(t *testing.T) {
+
+	var tests = []struct {
+		name       string
+		input      []interface{}
+		wantErr    bool
+		wantConfig GossConfig
+	}{
+		{
+			name: "defaults",
+			input: []interface{}{
+				map[string]interface{}{
+					"tests": []string{"example/goss"},
+				},
+			},
+			wantErr: false,
+			wantConfig: GossConfig{
+				Version:       "0.3.9",
+				Arch:          "amd64",
+				URL:           "https://github.com/aelsabbahy/goss/releases/download/v0.3.9/goss-linux-amd64",
+				DownloadPath:  "/tmp/goss-0.3.9-linux-amd64",
+				Username:      "",
+				Password:      "",
+				SkipInstall:   false,
+				Inspect:       false,
+				TargetOs:      Linux,
+				Tests:         []string{"example/goss"},
+				RetryTimeout:  "",
+				Sleep:         "",
+				UseSudo:       false,
+				SkipSSLChk:    false,
+				GossFile:      "",
+				VarsFile:      "",
+				VarsInline:    nil,
+				VarsEnv:       nil,
+				RemoteFolder:  "/tmp",
+				RemotePath:    "/tmp/goss",
+				Format:        "",
+				FormatOptions: "",
+				ctx:           fakeContext(),
+			},
+		},
+		{
+			name: "Windows",
+			input: []interface{}{
+				map[string]interface{}{
+					"tests":    []string{"example/goss"},
+					"targetOs": "Windows",
+					"vars_env": map[string]string{
+						"GOSS_USE_ALPHA": "1",
+					},
+				},
+			},
+			wantErr: false,
+			wantConfig: GossConfig{
+				Version:      "0.3.9",
+				Arch:         "amd64",
+				URL:          "https://github.com/aelsabbahy/goss/releases/download/v0.3.9/goss-alpha-windows-amd64.exe",
+				DownloadPath: "/tmp/goss-0.3.9-windows-amd64.exe",
+				Username:     "",
+				Password:     "",
+				SkipInstall:  false,
+				Inspect:      false,
+				TargetOs:     Windows,
+				Tests:        []string{"example/goss"},
+				RetryTimeout: "",
+				Sleep:        "",
+				UseSudo:      false,
+				SkipSSLChk:   false,
+				GossFile:     "",
+				VarsFile:     "",
+				VarsInline:   nil,
+				VarsEnv: map[string]string{
+					"GOSS_USE_ALPHA": "1",
+				},
+				RemoteFolder:  "/tmp",
+				RemotePath:    "/tmp/goss",
+				Format:        "",
+				FormatOptions: "",
+				ctx:           fakeContext(),
+			},
+		},
+		{
+			name: "Windows non alpha",
+			input: []interface{}{
+				map[string]interface{}{
+					"tests":    []string{"example/goss"},
+					"targetOs": "Windows",
+				},
+			},
+			wantErr: false,
+			wantConfig: GossConfig{
+				Version:       "0.3.9",
+				Arch:          "amd64",
+				URL:           "https://github.com/aelsabbahy/goss/releases/download/v0.3.9/goss-windows-amd64.exe",
+				DownloadPath:  "/tmp/goss-0.3.9-windows-amd64.exe",
+				Username:      "",
+				Password:      "",
+				SkipInstall:   false,
+				Inspect:       false,
+				TargetOs:      Windows,
+				Tests:         []string{"example/goss"},
+				RetryTimeout:  "",
+				Sleep:         "",
+				UseSudo:       false,
+				SkipSSLChk:    false,
+				GossFile:      "",
+				VarsFile:      "",
+				VarsInline:    nil,
+				VarsEnv:       nil,
+				RemoteFolder:  "/tmp",
+				RemotePath:    "/tmp/goss",
+				Format:        "",
+				FormatOptions: "",
+				ctx:           fakeContext(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Provisioner{
+				config: GossConfig{
+					ctx: interpolate.Context{},
+				},
+			}
+			err := p.Prepare(tt.input...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Provisioner.Prepare() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err == nil && !reflect.DeepEqual(p.config, tt.wantConfig) {
+				t.Error("configs do not match")
+				t.Logf("got config= %v", p.config)
+				t.Logf("want config= %v", tt.wantConfig)
+			}
+
+		})
+	}
+}
+
+func TestProvisioner_envVars(t *testing.T) {
+
+	tests := []struct {
+		name   string
+		config GossConfig
+		want   string
+	}{
+		{
+			name: "Linux",
+			config: GossConfig{
+				TargetOs:      Linux,
+				VarsEnv: map[string]string{
+					"somevar": "1",
+				},
+			},
+			want: "somevar=\"1\" ",
+		},
+		{
+			name: "Windows",
+			config: GossConfig{
+				TargetOs:      Windows,
+				VarsEnv: map[string]string{
+					"GOSS_USE_ALPHA": "1",
+				},
+			},
+			want: "set \"GOSS_USE_ALPHA=1\" && ",
+		},
+		{
+			name: "no vars windows",
+			config: GossConfig{
+				TargetOs:      Windows,
+				VarsEnv: map[string]string{},
+			},
+			want: "",
+		},
+		{
+			name: "no vars linux",
+			config: GossConfig{
+				TargetOs:      Linux,
+				VarsEnv: map[string]string{},
+			},
+			want: "",
+		},
+		{
+			name: "no configured target os",
+			config: GossConfig{
+				VarsEnv: map[string]string{
+					"somevar": "1",
+				},
+			},
+			want: "somevar=\"1\" ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Provisioner{
+				config: tt.config,
+			}
+			if got := p.envVars(); got != tt.want {
+				t.Errorf("Provisioner.envVars() = '%v', want '%v'", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProvisioner_mkDir(t *testing.T) {
+	tests := []struct {
+		name   string
+		config GossConfig
+		dir   string
+		wantcmd   string
+	}{
+		{
+			name: "linux",
+			config: GossConfig{
+				TargetOs: Linux,
+			},
+			dir: "/tmp",
+			wantcmd: "mkdir -p '/tmp'",
+		},
+		{
+			name: "windows",
+			config: GossConfig{
+				TargetOs: Windows,
+			},
+			dir: "/tmp",
+			wantcmd: "powershell /c mkdir -p '/tmp'",
+		},
+		{
+			name: "no configured os",
+			config: GossConfig{},
+			dir: "/tmp",
+			wantcmd: "mkdir -p '/tmp'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Provisioner{
+				config: tt.config,
+			}
+			if got := p.mkDir(tt.dir); got != tt.wantcmd {
+				t.Errorf("Provisioner.mkDir() = %v, want %v", got, tt.wantcmd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This provisioner is used to provide goss testing in the [image-builder project](https://image-builder.sigs.k8s.io/capi/goss/goss.html).  I recently added [Windows support to image-builder](https://github.com/kubernetes-sigs/image-builder/pull/382#issuecomment-707245381) and would like to run the goss test against it during provision in the same manner as the other images.  Goss also now has alpha support for [Windows](https://github.com/aelsabbahy/goss/blob/master/docs/platform-feature-parity.md).

I've updated the code here to support Windows and added a few tests. 

Here is the output of it running against a windows VM. It is using a custom goss url while I wait for the fix in goss https://github.com/aelsabbahy/goss/pull/666

```
==> vhd-windows-2019: Provisioning with Goss
==> vhd-windows-2019: Configured to run on Windows
    vhd-windows-2019: Creating directory: /tmp/goss
    vhd-windows-2019:
    vhd-windows-2019:
    vhd-windows-2019:     Directory: C:\tmp
    vhd-windows-2019:
    vhd-windows-2019:
    vhd-windows-2019: Mode                LastWriteTime         Length Name
    vhd-windows-2019: ----                -------------         ------ ----
    vhd-windows-2019: d-----       12/17/2020   6:37 PM                goss
    vhd-windows-2019:
    vhd-windows-2019:
    vhd-windows-2019: Installing Goss from, https://k8swin.blob.core.windows.net/k8s-windows/goss/goss-alpha-windows-amd64.exe
    vhd-windows-2019: Downloading Goss to /tmp/goss-windows-amd64.exe
==> vhd-windows-2019:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
==> vhd-windows-2019:                                  Dload  Upload   Total   Spent    Left  Speed
==> vhd-windows-2019: 100 11.5M  100 11.5M    0     0  11.5M      0  0:00:01 --:--:--  0:00:01 26.4M
==> vhd-windows-2019: 'chmod' is not recognized as an internal or external command,
==> vhd-windows-2019: operable program or batch file.
==> vhd-windows-2019: Uploading goss tests...
    vhd-windows-2019: Uploading vars file packer/goss/goss-vars.yaml
    vhd-windows-2019: Inline variables are --vars-inline {"ARCH":"amd64","OS":"windows","PROVIDER":"azure","containerd_version":"1.4.3","kubernetes_cni_source_type":"","kubernetes_cni_version":"","kubernetes_source_type":"pkg","kubernetes_version":"v1.17.11"}
    vhd-windows-2019: Env variables are set "GOSS_USE_ALPHA=1" &&
    vhd-windows-2019: Uploading Dir packer/goss
    vhd-windows-2019: Creating directory: /tmp/goss/goss
    vhd-windows-2019:
    vhd-windows-2019:
    vhd-windows-2019:     Directory: C:\tmp\goss
    vhd-windows-2019:
    vhd-windows-2019:
    vhd-windows-2019: Mode                LastWriteTime         Length Name
    vhd-windows-2019: ----                -------------         ------ ----
    vhd-windows-2019: d-----       12/17/2020   6:37 PM                goss
    vhd-windows-2019:
    vhd-windows-2019:
==> vhd-windows-2019: 
==> vhd-windows-2019: 
==> vhd-windows-2019: 
==> vhd-windows-2019: Running goss tests...
==> vhd-windows-2019: Running GOSS render command: cd /tmp/goss && set "GOSS_USE_ALPHA=1" &&  /tmp/goss-windows-amd64.exe --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline {"ARCH":"amd64","OS":"windows","PROVIDER":"azure","containerd_version":"1.4.3","kubernetes_cni_source_type":"","kubernetes_cni_version":"","kubernetes_source_type":"pkg","kubernetes_version":"v1.17.11"} render > /tmp/goss-spec.yaml
==> vhd-windows-2019: Goss render ran successfully
==> vhd-windows-2019: Running GOSS render debug command: cd /tmp/goss && set "GOSS_USE_ALPHA=1" &&  /tmp/goss-windows-amd64.exe --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline {"ARCH":"amd64","OS":"windows","PROVIDER":"azure","containerd_version":"1.4.3","kubernetes_cni_source_type":"","kubernetes_cni_version":"","kubernetes_source_type":"pkg","kubernetes_version":"v1.17.11"} render -d > /tmp/debug-goss-spec.yaml
==> vhd-windows-2019: Goss render debug ran successfully
==> vhd-windows-2019: Running GOSS validate command: cd /tmp/goss &&  set "GOSS_USE_ALPHA=1" &&  /tmp/goss-windows-amd64.exe --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline {"ARCH":"amd64","OS":"windows","PROVIDER":"azure","containerd_version":"1.4.3","kubernetes_cni_source_type":"","kubernetes_cni_version":"","kubernetes_source_type":"pkg","kubernetes_version":"v1.17.11"} validate --retry-timeout 0s --sleep 1s -f json -o pretty
    vhd-windows-2019: {
    vhd-windows-2019:     "results": [
    vhd-windows-2019:         {
    vhd-windows-2019:             "duration": 1587645100,
    vhd-windows-2019:             "err": null,
    vhd-windows-2019:             "expected": [
    vhd-windows-2019:                 "0"
    vhd-windows-2019:             ],
    vhd-windows-2019:             "found": [
    vhd-windows-2019:                 "0"
    vhd-windows-2019:             ],
    vhd-windows-2019:             "human": "",
    vhd-windows-2019:             "meta": null,
    vhd-windows-2019:             "property": "exit-status",
    vhd-windows-2019:             "resource-id": "kubectl.exe version --short --client=true -o json | powershell -Command \"($input | convertfrom-json).clientVersion.gitVersion\"",
    vhd-windows-2019:             "resource-type": "Command",
    vhd-windows-2019:             "result": 0,
    vhd-windows-2019:             "successful": true,
    vhd-windows-2019:             "summary-line": "Command: kubectl.exe version --short --client=true -o json | powershell -Command \"($input | convertfrom-json).clientVersion.gitVersion\": exit-status: matches expectation: [0]",
    vhd-windows-2019:             "test-type": 0,
    vhd-windows-2019:             "title": ""
    vhd-windows-2019:         },
    vhd-windows-2019:         {
    vhd-windows-2019:             "duration": 1587645100,
    vhd-windows-2019:             "err": null,
    vhd-windows-2019:             "expected": [
    vhd-windows-2019:                 "0"
    vhd-windows-2019:             ],
    vhd-windows-2019:             "found": [
    vhd-windows-2019:                 "0"
    vhd-windows-2019:             ],
    vhd-windows-2019:             "human": "",
    vhd-windows-2019:             "meta": null,
    vhd-windows-2019:             "property": "exit-status",
    vhd-windows-2019:             "resource-id": "kubeadm.exe version -o json | powershell -Command \"($input | convertfrom-json).clientVersion.gitVersion\"",
    vhd-windows-2019:             "resource-type": "Command",
    vhd-windows-2019:             "result": 0,
    vhd-windows-2019:             "successful": true,
    vhd-windows-2019:             "summary-line": "Command: kubeadm.exe version -o json | powershell -Command \"($input | convertfrom-json).clientVersion.gitVersion\": exit-status: matches expectation: [0]",
    vhd-windows-2019:             "test-type": 0,
    vhd-windows-2019:             "title": ""
    vhd-windows-2019:         },
    vhd-windows-2019:         {
    vhd-windows-2019:             "duration": 1822111700,
    vhd-windows-2019:             "err": null,
    vhd-windows-2019:             "expected": [
    vhd-windows-2019:                 "0"
    vhd-windows-2019:             ],
    vhd-windows-2019:             "found": [
    vhd-windows-2019:                 "0"
    vhd-windows-2019:             ],
    vhd-windows-2019:             "human": "",
    vhd-windows-2019:             "meta": null,
    vhd-windows-2019:             "property": "exit-status",
    vhd-windows-2019:             "resource-id": "kubelet.exe --version | powershell -command \"$input\".Split(\" \")[1]",
    vhd-windows-2019:             "resource-type": "Command",
    vhd-windows-2019:             "result": 0,
    vhd-windows-2019:             "successful": true,
    vhd-windows-2019:             "summary-line": "Command: kubelet.exe --version | powershell -command \"$input\".Split(\" \")[1]: exit-status: matches expectation: [0]",
    vhd-windows-2019:             "test-type": 0,
    vhd-windows-2019:             "title": ""
    vhd-windows-2019:         }
    vhd-windows-2019:     ],
    vhd-windows-2019:     "summary": {
    vhd-windows-2019:         "failed-count": 0,
    vhd-windows-2019:         "summary-line": "Count: 3, Failed: 0, Duration: 1.822s",
    vhd-windows-2019:         "test-count": 3,
    vhd-windows-2019:         "total-duration": 1822111700
    vhd-windows-2019:     }
    vhd-windows-2019: }
==> vhd-windows-2019: Goss validate ran successfully
==> vhd-windows-2019: 
==> vhd-windows-2019: 
==> vhd-windows-2019: 
==> vhd-windows-2019: Downloading spec file and debug info
    vhd-windows-2019: Downloading Goss specs from, /tmp/goss-spec.yaml and /tmp/debug-goss-spec.yaml to current dir
```