### PR TITLE
Update targetOs to target_os to fix packer errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There is an example packer build with goss tests in the `example/` directory.
     "format": "",
     "goss_file": "",
     "vars_file": "",
-    "targetOs": "Linux",
+    "target_os": "Linux",
     "vars_env": {
       "ARCH": "amd64",
       "PROVIDER": "{{user `cloud-provider`}}"
@@ -70,7 +70,7 @@ Goss spec file and debug spec file (`goss render -d`) are downloaded to `/tmp` f
 
 ## Windows support
 
-This now has support for Windows. Set the optional parameter `targetOs` to `Windows`. Currently, the `vars_env` parameter must include `GOSS_USE_ALPHA=1` as specified in [goss's feature parity document](https://github.com/aelsabbahy/goss/blob/master/docs/platform-feature-parity.md#platform-feature-parity).  In the future when goss come of of alpha for Windows this parameter will not be required.
+This now has support for Windows. Set the optional parameter `target_os` to `Windows`. Currently, the `vars_env` parameter must include `GOSS_USE_ALPHA=1` as specified in [goss's feature parity document](https://github.com/aelsabbahy/goss/blob/master/docs/platform-feature-parity.md#platform-feature-parity).  In the future when goss come of of alpha for Windows this parameter will not be required.
 
 ## Installation
 

--- a/packer-provisioner-goss.go
+++ b/packer-provisioner-goss.go
@@ -37,7 +37,7 @@ type GossConfig struct {
 	Password     string
 	SkipInstall  bool `mapstructure:"skip_install"`
 	Inspect      bool
-	TargetOs     string
+	TargetOs     string `mapstructure:"target_os"`
 
 	// An array of tests to run.
 	Tests []string

--- a/packer-provisioner-goss.hcl2spec.go
+++ b/packer-provisioner-goss.hcl2spec.go
@@ -18,7 +18,7 @@ type FlatGossConfig struct {
 	Password      *string           `cty:"password" hcl:"password"`
 	SkipInstall   *bool             `mapstructure:"skip_install" cty:"skip_install" hcl:"skip_install"`
 	Inspect       *bool             `cty:"inspect" hcl:"inspect"`
-	TargetOs      *string           `cty:"target_os" hcl:"target_os"`
+	TargetOs      *string           `mapstructure:"target_os" cty:"target_os" hcl:"target_os"`
 	Tests         []string          `cty:"tests" hcl:"tests"`
 	RetryTimeout  *string           `mapstructure:"retry_timeout" cty:"retry_timeout" hcl:"retry_timeout"`
 	Sleep         *string           `mapstructure:"sleep" cty:"sleep" hcl:"sleep"`

--- a/packer-provisioner-goss_test.go
+++ b/packer-provisioner-goss_test.go
@@ -72,8 +72,8 @@ func TestProvisioner_Prepare(t *testing.T) {
 			name: "Windows",
 			input: []interface{}{
 				map[string]interface{}{
-					"tests":    []string{"example/goss"},
-					"targetOs": "Windows",
+					"tests":     []string{"example/goss"},
+					"target_os": "Windows",
 					"vars_env": map[string]string{
 						"GOSS_USE_ALPHA": "1",
 					},
@@ -112,8 +112,8 @@ func TestProvisioner_Prepare(t *testing.T) {
 			name: "Windows non alpha",
 			input: []interface{}{
 				map[string]interface{}{
-					"tests":    []string{"example/goss"},
-					"targetOs": "Windows",
+					"tests":     []string{"example/goss"},
+					"target_os": "Windows",
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
The targetOs version of the parameter wasn't usable by packer directly,
and I received an error attempting to use the merged version of the
changes to use the 1.7 packer release. Turns out that when I rebased
onto the windows support, I failed to directly test & ended up failing with
a recurrence of the problem reported in issue 40, and specifically, the
newer problem reported
[here](https://github.com/YaleUniversity/packer-provisioner-goss/issues/40#issuecomment-792780370)

The solution was the same as for the struct tags added in the 1.7 compatibility
upgrade, which was to provide a mapstructure struct tag. Apologies
for missing the new parameter when I rebased.