### PR TITLE
replace double quotes with single quotes

### DIFF
--- a/packer-provisioner-goss.go
+++ b/packer-provisioner-goss.go
@@ -441,8 +441,8 @@ func (p *Provisioner) inline_vars() string {
 		if err == nil {
 			switch p.config.TargetOs {
 			case windows:
-				// don't include single quotes which confused cmd parsing
-				return fmt.Sprintf("--vars-inline %s", string(inlineVarsJson))
+				// don't include single quotes around the json string and replace " with ' otherwise the variables are not recognised
+				return fmt.Sprintf("--vars-inline %s", strings.Replace(string(inlineVarsJson), "\"", "'", -1))
 			default:
 				return fmt.Sprintf("--vars-inline '%s'", string(inlineVarsJson))
 			}


### PR DESCRIPTION
Found a bug on the windows command line that doesn't unmarshall inline variable json strings into goss that have " and not single quotes e.g.
Not working
`{"OS":"windows"}`
working
`{'OS':'windows'}`