### PR TITLE
Update packer-plugin-sdk to use version 0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/hashicorp/hcl/v2 v2.8.0
-	github.com/hashicorp/packer-plugin-sdk v0.0.11
+	github.com/hashicorp/packer-plugin-sdk v0.1.0
 	github.com/zclconf/go-cty v1.7.0
 )


### PR DESCRIPTION
A recent update in the packer-plugin-sdk was a breaking change in Packer's internal marshalling for communicating with plugins : https://github.com/hashicorp/packer-plugin-sdk/pull/31

It could be that this project is not impacted, but updating to v0.1 will make sure it's not the case.
I didn't update the `go.sum` file, this will happen automatically next time you run `go ...` in the project folder.