### PR TITLE
Initialize plugin as multi-component

### DIFF
--- a/packer-provisioner-goss.go
+++ b/packer-provisioner-goss.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/plugin"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+	"github.com/hashicorp/packer-plugin-sdk/version"
 )
 
 const (
@@ -103,6 +104,7 @@ type Provisioner struct {
 func main() {
 	pps := plugin.NewSet()
 	pps.RegisterProvisioner(plugin.DEFAULT_NAME, new(Provisioner))
+	pps.SetVersion(version.InitializePluginVersion("3.1.4", ""))
 	err := pps.Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/packer-provisioner-goss.go
+++ b/packer-provisioner-goss.go
@@ -101,12 +101,13 @@ type Provisioner struct {
 }
 
 func main() {
-	server, err := plugin.Server()
+	pps := plugin.NewSet()
+	pps.RegisterProvisioner(plugin.DEFAULT_NAME, new(Provisioner))
+	err := pps.Run()
 	if err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
 	}
-	server.RegisterProvisioner(new(Provisioner))
-	server.Serve()
 }
 
 func (p *Provisioner) ConfigSpec() hcldec.ObjectSpec {


### PR DESCRIPTION
This change is required for plugin to be installable using `required_plugins` feature(https://github.com/YaleUniversity/packer-provisioner-goss/issues/58).

Done according to official docs https://www.packer.io/docs/plugins/creation#plugin-development-basics

Signed-off-by: Ondrej Vasko <o.vasko@pan-net.eu>