### PR TITLE
build: Add linux arm64 to build targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
-      - name: Describe plugin
-        id: plugin_describe
-        run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
+
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
@@ -34,4 +32,3 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          API_VERSION: ${{ steps.plugin_describe.outputs.api_version }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,12 +31,11 @@ builds:
       - -trimpath
     ldflags:
       - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
-    goos:
-      - linux
-      - windows
-      - darwin
-    goarch:
-      - amd64
+    targets:
+      - linux_amd64
+      - linux_arm64
+      - darwin_amd64
+      - windows_amd64
 archives:
   -
     builds:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,8 +12,8 @@ builds:
       post:
         # This will check plugin compatibility against latest version of Packer
         - cmd: |
-            go install github.com/hashicorp/packer/cmd/packer-plugins-check@latest &&
-            packer-plugins-check -load={{ .Name }}
+            go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@latest &&
+            packer-sdc plugin-check -load={{ .Name }}
           dir: "{{ dir .Path}}"
     flags:
       - -trimpath

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,6 @@ builds:
       - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
     targets:
       - linux_amd64
-    binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
   -
     id: default
     mod_timestamp: '{{ .CommitTimestamp }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,20 +9,16 @@ builds:
     id: plugin-check
     mod_timestamp: '{{ .CommitTimestamp }}'
     hooks:
+      # This will check plugin compatibility against latest version of Packer
       post:
-        # This will check plugin compatibility against latest version of Packer
-        - cmd: |
-            go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@latest &&
-            packer-sdc plugin-check -load={{ .Name }}
-          dir: "{{ dir .Path}}"
+        - go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@latest
+        - bash -ec 'cd "{{ dir .Path}}" && packer-sdc plugin-check {{ .Name }}'
     flags:
       - -trimpath
     ldflags:
       - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
-    goos:
-      - linux
-    goarch:
-      - amd64
+    targets:
+      - linux_amd64
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
   -
     id: default


### PR DESCRIPTION
See https://goreleaser.com/customization/build/ example config under key
`builds[*].targets`.- build: Add linux arm64 to build targets

Also use moved packer plugin check command.

Fixes #60 