### PR TITLE
Bump packer-plugin-sdk to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.16
 require (
 	github.com/apparentlymart/go-textseg/v12 v12.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.10.0
-	github.com/hashicorp/packer-plugin-sdk v0.2.3
+	github.com/hashicorp/packer-plugin-sdk v0.3.2
 	github.com/zclconf/go-cty v1.8.3
 )


### PR DESCRIPTION
Current version of packer-plugin (v0.2.3) has an old `go-getter` dependency (v2.0.0)  that has CVEs - [30323](https://osspi.eng.vmware.com/api/v3/vulnerabilities/CVE-2022-30323/overview/), [30322](https://osspi.eng.vmware.com/api/v3/vulnerabilities/CVE-2022-30322/overview/), [30321](https://osspi.eng.vmware.com/api/v3/vulnerabilities/CVE-2022-30321/overview/)

Latest release of packer-plugin-sdk (v0.3.2) has an updated go-getter [2.1.0](https://github.com/hashicorp/packer-plugin-sdk/blob/main/go.mod#L32) that resolves these.

After this is bumped, a new tag will be needed to be included in the [image-builder](https://github.com/kubernetes-sigs/image-builder) project. 